### PR TITLE
feat: add render subcommand and default to NumCPU workers

### DIFF
--- a/go/cmd/lit-ssr/main.go
+++ b/go/cmd/lit-ssr/main.go
@@ -1,15 +1,19 @@
 // lit-ssr is a CLI for server-rendering Lit web components via WASM.
 //
 // Component definitions are loaded from JS/TS files at startup and
-// automatically bundled with esbuild. It reads NUL-terminated HTML from
-// stdin, renders each with Declarative Shadow DOM, and writes
-// NUL-terminated results to stdout.
+// automatically bundled with esbuild. In the default (stdin) mode it reads
+// NUL-terminated HTML from stdin, renders each with Declarative Shadow DOM,
+// and writes NUL-terminated results to stdout.
+//
+// The render subcommand processes HTML files in-place, useful for SSG
+// post-processing workflows.
 //
 // Usage:
 //
-//	lit-ssr src/my-card.ts src/my-alert.ts
-//	lit-ssr --dir ./components/
-//	lit-ssr --skip-bundle dist/components.js
+//	lit-ssr src/my-card.ts src/my-alert.ts          # stdin/stdout NUL protocol
+//	lit-ssr --dir ./components/                     # stdin/stdout NUL protocol
+//	lit-ssr --skip-bundle dist/components.js        # stdin/stdout NUL protocol
+//	lit-ssr render --dir ./components/ out/**/*.html # render files in-place
 package main
 
 import (
@@ -25,6 +29,13 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "render" {
+		os.Exit(renderMain(os.Args[2:]))
+	}
+	os.Exit(stdinMain())
+}
+
+func stdinMain() int {
 	var skipBundle string
 	var dir string
 	flag.StringVar(&skipBundle, "skip-bundle", "", "path to a pre-bundled JS file (skips esbuild)")
@@ -36,9 +47,9 @@ func main() {
 	renderer, err := createRenderer(ctx, skipBundle, dir, flag.Args())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "lit-ssr: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
-	defer renderer.Close(ctx)
+	defer func() { _ = renderer.Close(ctx) }()
 
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -54,14 +65,80 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "lit-ssr: %v\n", err)
 		}
-		os.Stdout.WriteString(output)
-		os.Stdout.Write([]byte{0})
+		_, _ = os.Stdout.WriteString(output)
+		_, _ = os.Stdout.Write([]byte{0})
 	}
 
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintf(os.Stderr, "lit-ssr: read error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+func renderMain(args []string) int {
+	fs := flag.NewFlagSet("render", flag.ExitOnError)
+	var skipBundle string
+	var dir string
+	fs.StringVar(&skipBundle, "skip-bundle", "", "path to a pre-bundled JS file (skips esbuild)")
+	fs.StringVar(&dir, "dir", "", "directory of component source files (*.ts, *.js)")
+	_ = fs.Parse(args)
+
+	htmlFiles := fs.Args()
+	if len(htmlFiles) == 0 {
+		fmt.Fprintf(os.Stderr, "lit-ssr render: no HTML files specified\n")
+		return 1
+	}
+
+	if skipBundle == "" && dir == "" {
+		fmt.Fprintf(os.Stderr, "lit-ssr render: --dir or --skip-bundle is required\n")
+		return 1
+	}
+
+	ctx := context.Background()
+
+	renderer, err := createRenderer(ctx, skipBundle, dir, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
+		return 1
+	}
+	defer func() { _ = renderer.Close(ctx) }()
+
+	// Read all files
+	inputs := make([]string, len(htmlFiles))
+	perms := make([]os.FileMode, len(htmlFiles))
+	for i, path := range htmlFiles {
+		info, err := os.Stat(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
+			return 1
+		}
+		perms[i] = info.Mode().Perm()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
+			return 1
+		}
+		inputs[i] = string(data)
+	}
+
+	results, err := renderer.RenderBatch(ctx, inputs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
+		return 1
+	}
+
+	failed := false
+	for i, result := range results {
+		if err := os.WriteFile(htmlFiles[i], []byte(result), perms[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "lit-ssr render: write %s: %v\n", htmlFiles[i], err)
+			failed = true
+		}
+	}
+	if failed {
+		return 1
+	}
+	return 0
 }
 
 func createRenderer(ctx context.Context, skipBundle, dir string, args []string) (*litssr.Renderer, error) {
@@ -74,7 +151,7 @@ func createRenderer(ctx context.Context, skipBundle, dir string, args []string) 
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", skipBundle, err)
 		}
-		return litssr.New(ctx, string(data), 1)
+		return litssr.New(ctx, string(data), 0)
 	}
 
 	// Collect files from --dir and/or positional args
@@ -125,7 +202,7 @@ func createRenderer(ctx context.Context, skipBundle, dir string, args []string) 
 		deduped = append(deduped, f)
 	}
 
-	return litssr.NewFromFiles(ctx, deduped, 1)
+	return litssr.NewFromFiles(ctx, deduped, 0)
 }
 
 func splitNul(data []byte, atEOF bool) (advance int, token []byte, err error) {

--- a/go/cmd/lit-ssr/main.go
+++ b/go/cmd/lit-ssr/main.go
@@ -84,6 +84,9 @@ func renderMain(args []string) int {
 	fs.StringVar(&skipBundle, "skip-bundle", "", "path to a pre-bundled JS file (skips esbuild)")
 	fs.StringVar(&dir, "dir", "", "directory of component source files (*.ts, *.js)")
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 1
 	}
 

--- a/go/cmd/lit-ssr/main.go
+++ b/go/cmd/lit-ssr/main.go
@@ -77,12 +77,15 @@ func stdinMain() int {
 }
 
 func renderMain(args []string) int {
-	fs := flag.NewFlagSet("render", flag.ExitOnError)
+	fs := flag.NewFlagSet("render", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
 	var skipBundle string
 	var dir string
 	fs.StringVar(&skipBundle, "skip-bundle", "", "path to a pre-bundled JS file (skips esbuild)")
 	fs.StringVar(&dir, "dir", "", "directory of component source files (*.ts, *.js)")
-	_ = fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
 
 	htmlFiles := fs.Args()
 	if len(htmlFiles) == 0 {
@@ -125,9 +128,10 @@ func renderMain(args []string) int {
 	results, err := renderer.RenderBatch(ctx, inputs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
+		return 1
 	}
 
-	failed := err != nil
+	failed := false
 	for i, result := range results {
 		if err := writeFileAtomic(htmlFiles[i], []byte(result), perms[i]); err != nil {
 			fmt.Fprintf(os.Stderr, "lit-ssr render: write %s: %v\n", htmlFiles[i], err)

--- a/go/cmd/lit-ssr/main.go
+++ b/go/cmd/lit-ssr/main.go
@@ -125,12 +125,11 @@ func renderMain(args []string) int {
 	results, err := renderer.RenderBatch(ctx, inputs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "lit-ssr render: %v\n", err)
-		return 1
 	}
 
-	failed := false
+	failed := err != nil
 	for i, result := range results {
-		if err := os.WriteFile(htmlFiles[i], []byte(result), perms[i]); err != nil {
+		if err := writeFileAtomic(htmlFiles[i], []byte(result), perms[i]); err != nil {
 			fmt.Fprintf(os.Stderr, "lit-ssr render: write %s: %v\n", htmlFiles[i], err)
 			failed = true
 		}
@@ -139,6 +138,40 @@ func renderMain(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+// writeFileAtomic writes data to a temp file in the same directory, syncs it,
+// then renames it over dst to avoid truncating the original on failure.
+func writeFileAtomic(dst string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(dst)
+	tmp, err := os.CreateTemp(dir, ".lit-ssr-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, dst)
 }
 
 func createRenderer(ctx context.Context, skipBundle, dir string, args []string) (*litssr.Renderer, error) {

--- a/go/cmd/lit-ssr/main.go
+++ b/go/cmd/lit-ssr/main.go
@@ -171,7 +171,11 @@ func writeFileAtomic(dst string, data []byte, perm os.FileMode) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, dst)
+	if err := os.Rename(tmpPath, dst); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 func createRenderer(ctx context.Context, skipBundle, dir string, args []string) (*litssr.Renderer, error) {

--- a/go/cmd/lit-ssr/main_test.go
+++ b/go/cmd/lit-ssr/main_test.go
@@ -20,6 +20,9 @@ func TestMain(m *testing.M) {
 	defer func() { _ = os.RemoveAll(tmp) }()
 
 	binaryPath = filepath.Join(tmp, "lit-ssr")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
 	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/go/cmd/lit-ssr/main_test.go
+++ b/go/cmd/lit-ssr/main_test.go
@@ -17,8 +17,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = os.RemoveAll(tmp) }()
-
 	binaryPath = filepath.Join(tmp, "lit-ssr")
 	if runtime.GOOS == "windows" {
 		binaryPath += ".exe"
@@ -29,7 +27,9 @@ func TestMain(m *testing.M) {
 		panic("go build failed: " + err.Error())
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
 }
 
 func testdataPath(name string) string {

--- a/go/cmd/lit-ssr/main_test.go
+++ b/go/cmd/lit-ssr/main_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var binaryPath string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "lit-ssr-test-*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	binaryPath = filepath.Join(tmp, "lit-ssr")
+	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic("go build failed: " + err.Error())
+	}
+
+	os.Exit(m.Run())
+}
+
+func testdataPath(name string) string {
+	return filepath.Join("..", "..", "testdata", name)
+}
+
+func TestStdinMode(t *testing.T) {
+	input := "<test-card><h2 slot=\"header\">Hi</h2><p>Body</p></test-card>\x00"
+
+	cmd := exec.Command(binaryPath, "--skip-bundle", testdataPath("test-components.js"))
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("lit-ssr exited with error: %v\nstderr: %s", err, stderr.String())
+	}
+
+	// Output should be NUL-terminated
+	out := stdout.String()
+	if !strings.HasSuffix(out, "\x00") {
+		t.Fatalf("expected NUL-terminated output, got: %q", out)
+	}
+
+	// Strip trailing NUL and compare with golden
+	got := strings.TrimSuffix(out, "\x00")
+	want, err := os.ReadFile(testdataPath("card.golden"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("mismatch\ngot:\n%s\nwant:\n%s", got, string(want))
+	}
+}
+
+func TestStdinMultiple(t *testing.T) {
+	input := "<test-badge state=\"success\">up</test-badge>\x00<test-sheet>styled</test-sheet>\x00"
+
+	cmd := exec.Command(binaryPath, "--skip-bundle", testdataPath("test-components.js"))
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("lit-ssr exited with error: %v\nstderr: %s", err, stderr.String())
+	}
+
+	parts := strings.Split(stdout.String(), "\x00")
+	// Last element after trailing NUL is empty
+	if len(parts) < 3 {
+		t.Fatalf("expected 2 NUL-delimited results, got output: %q", stdout.String())
+	}
+
+	goldens := []string{"badge", "sheet"}
+	for i, name := range goldens {
+		want, err := os.ReadFile(testdataPath(name + ".golden"))
+		if err != nil {
+			t.Fatalf("read golden %s: %v", name, err)
+		}
+		if parts[i] != string(want) {
+			t.Errorf("result %d (%s): mismatch\ngot:\n%s\nwant:\n%s", i, name, parts[i], string(want))
+		}
+	}
+}
+
+func TestRenderSubcommand(t *testing.T) {
+	// Set up temp dir with HTML files to render
+	tmp := t.TempDir()
+
+	cardHTML := `<test-card><h2 slot="header">Hi</h2><p>Body</p></test-card>`
+	badgeHTML := `<test-badge state="success">up</test-badge>`
+
+	cardPath := filepath.Join(tmp, "card.html")
+	badgePath := filepath.Join(tmp, "badge.html")
+
+	if err := os.WriteFile(cardPath, []byte(cardHTML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(badgePath, []byte(badgeHTML), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(binaryPath, "render",
+		"--skip-bundle", testdataPath("test-components.js"),
+		cardPath, badgePath)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("lit-ssr render exited with error: %v\nstderr: %s", err, stderr.String())
+	}
+
+	// Check card output matches golden
+	gotCard, err := os.ReadFile(cardPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCard, err := os.ReadFile(testdataPath("card.golden"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotCard) != string(wantCard) {
+		t.Errorf("card.html mismatch\ngot:\n%s\nwant:\n%s", gotCard, wantCard)
+	}
+
+	// Check badge output matches golden
+	gotBadge, err := os.ReadFile(badgePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBadge, err := os.ReadFile(testdataPath("badge.golden"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotBadge) != string(wantBadge) {
+		t.Errorf("badge.html mismatch\ngot:\n%s\nwant:\n%s", gotBadge, wantBadge)
+	}
+
+	// Verify file permissions preserved
+	info, err := os.Stat(badgePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Errorf("badge.html permissions: got %o, want 640", info.Mode().Perm())
+	}
+}
+
+func TestRenderNoFiles(t *testing.T) {
+	cmd := exec.Command(binaryPath, "render", "--skip-bundle", testdataPath("test-components.js"))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit, got success")
+	}
+	if !strings.Contains(stderr.String(), "no HTML files") {
+		t.Errorf("expected 'no HTML files' in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestRenderNoSource(t *testing.T) {
+	cmd := exec.Command(binaryPath, "render", "some-file.html")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit, got success")
+	}
+	if !strings.Contains(stderr.String(), "--dir or --skip-bundle is required") {
+		t.Errorf("expected source required message in stderr, got: %s", stderr.String())
+	}
+}

--- a/go/cmd/lit-ssr/main_test.go
+++ b/go/cmd/lit-ssr/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -146,13 +147,15 @@ func TestRenderSubcommand(t *testing.T) {
 		t.Errorf("badge.html mismatch\ngot:\n%s\nwant:\n%s", gotBadge, wantBadge)
 	}
 
-	// Verify file permissions preserved
-	info, err := os.Stat(badgePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o640 {
-		t.Errorf("badge.html permissions: got %o, want 640", info.Mode().Perm())
+	// Verify file permissions preserved (Unix only; Windows doesn't support fine-grained mode bits)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(badgePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o640 {
+			t.Errorf("badge.html permissions: got %o, want 640", info.Mode().Perm())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `lit-ssr render` subcommand for in-place HTML file processing, enabling SSG post-processing workflows:
  ```
  lit-ssr render --dir ./components/ site/public/**/*.html
  lit-ssr render --skip-bundle dist/bundle.js out/*.html
  ```
- Default worker count to `NumCPU()` (pass 0 instead of hardcoded 1) in both `createRenderer` call sites
- Add CLI tests covering stdin NUL protocol (single + multi), render subcommand with golden file comparison, file permission preservation, and error cases

## Test plan
- [x] `go test ./... -count=1` passes
- [x] `golangci-lint run ./cmd/lit-ssr/...` clean
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)